### PR TITLE
Fixed a typo in the code

### DIFF
--- a/apps/servers/tests/api/dummy_api.py
+++ b/apps/servers/tests/api/dummy_api.py
@@ -1,1 +1,1 @@
-print('dummy apui')
+print('dummy api')


### PR DESCRIPTION
Fixed a typo under the section of 
Recipe Hub --> apps --> servers --> tests --> api --> dummy_api.py
In the print message it was written "apui" instead of "api". So fixed that 